### PR TITLE
Bash short cut

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,16 +1,62 @@
 package main
 
 import (
+	"flag"
 	"github.com/bowenislandsong/winc_node_setup/pkg/config"
 	"github.com/bowenislandsong/winc_node_setup/pkg/ec2_instances"
 	"log"
+	"os"
 )
 
 func main() {
-	sessAWS := config.AWSConfigSess()
-	oc, err := config.OpenShiftConfig()
-	if err != nil {
-		log.Fatalf("Failed to get client, %v", err)
+	if len(os.Args) < 2 {
+		log.Fatal("Please use one argument either 'create' or 'destroy' a node")
 	}
-	ec2_instances.CreateEC2WinC(sessAWS, oc, "", "", "")
+	createFlag := flag.NewFlagSet("create", flag.ExitOnError)
+	destroyFlag := flag.NewFlagSet("destroy", flag.ExitOnError)
+	if os.Args[1] == "create" {
+		// subflags of create
+		// openshift cluster region
+		credPath := createFlag.String("awscred", "", "Required: absolute path of aws credentials")
+		credAccount := createFlag.String("awsaccount", "openshift-dev", "account name of the aws credentials") // Default accounts for dev team in OpenShift
+		dir := createFlag.String("dir", "./", "path to 'winc-setup.json'.")
+		region := createFlag.String("region", "us-east-1", "Set region where the instance will be running on aws") // Default region for Boston Office or East Coast (virginia)
+		// existing kubeconfig for the openshift cluster (one per cluster)
+		kubeConfigPath := createFlag.String("kubeconfig", "", "Required: absolute path to the kubeconfig file")
+		// Set image by AMI ID. Default using Aravindh's firewall disabled image ami-0943eb2c39917fc11 (Does not always have firewall disabled) AWS windows server 2019 is ami-04ca2d0801450d495
+		imageId := createFlag.String("imageid", "ami-0943eb2c39917fc11", "Set instance AMI ID tobe deployed. AWS windows server 2019 is ami-04ca2d0801450d495.")
+		// set instance type. Free tier is t2.micro
+		instanceType := createFlag.String("instancetype", "m4.large", "Set instance type tobe deployed. Free tier is t2.micro.")
+		// set key name for authentication
+		keyName := createFlag.String("keyname", "libra", "Set key.pem for accessing the instance.")
+		// parse flags
+		err := createFlag.Parse(os.Args[2:])
+		if err != nil {
+			println("Please get help with 'create -h'.")
+		}
+		sessAWS := config.AWSConfigSess(credPath, credAccount, region)
+		oc, err := config.OpenShiftConfig(kubeConfigPath)
+		if err != nil {
+			log.Fatalf("Failed to get client, %v", err)
+		}
+		*dir = *dir + "winc-setup.json"
+		ec2_instances.CreateEC2WinC(sessAWS, oc, imageId, instanceType, keyName, dir)
+	} else if os.Args[1] == "destroy" {
+		// subflags of destroy
+		credPath := destroyFlag.String("awscred", "", "Required: absolute path of aws credentials")
+		credAccount := destroyFlag.String("awsaccount", "openshift-dev", "account name of the aws credentials")     // Default accounts for dev team in OpenShift
+		region := destroyFlag.String("region", "us-east-1", "Set region where the instance will be running on aws") // Default region for Boston Office or East Coast (virginia)
+		dir := destroyFlag.String("dir", "./", "path to 'winc-setup.json'.")
+		// parse flags
+		err := destroyFlag.Parse(os.Args[2:])
+		if err != nil {
+			println("Please get help with 'destroy -h'.")
+		}
+		sessAWS := config.AWSConfigSess(credPath, credAccount, region)
+		*dir = *dir + "winc-setup.json"
+		ec2_instances.DestroyEC2WinC(sessAWS, dir)
+	} else {
+		log.Fatal("Please use one argument either 'create' or 'destroy' a node")
+	}
+
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	svc := config.AWSConfig()
+	svc, svcIAM := config.AWSConfig()
 	client, err := config.ConfigOpenShift()
 	if err != nil {
 		log.Fatalf("Failed to get client, %v", err)
@@ -17,5 +17,5 @@ func main() {
 	if err != nil {
 		log.Fatalf("We failed to find our vpc, %v", err)
 	}
-	ec2_instances.CreateEC2WinC(svc, vpcID, infra.Status.InfrastructureName, "", "", "")
+	ec2_instances.CreateEC2WinC(svc, svcIAM, vpcID, infra.Status.InfrastructureName, "", "", "")
 }

--- a/main.go
+++ b/main.go
@@ -12,10 +12,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to get client, %v", err)
 	}
-	infra := config.GetInfrastrcture(client)
-	vpcID, err := config.GetVPCByInfrastructure(svc, infra)
+	infra := ec2_instances.GetInfrastrcture(client)
+	vpcID, err := ec2_instances.GetVPCByInfrastructure(svc, infra)
 	if err != nil {
 		log.Fatalf("We failed to find our vpc, %v", err)
 	}
-	ec2_instances.CreateEC2WinC(svc, vpcID, "", "", "")
+	ec2_instances.CreateEC2WinC(svc, vpcID, infra.Status.InfrastructureName, "", "", "")
 }

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to get client, %v", err)
 	}
-	infraID := config.GetInfrastrctureName(client)
-	vpcID, err := config.GetVPCByInfrastructureName(svc, infraID)
+	infra := config.GetInfrastrcture(client)
+	vpcID, err := config.GetVPCByInfrastructure(svc, infra)
 	if err != nil {
 		log.Fatalf("We failed to find our vpc, %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -7,15 +7,10 @@ import (
 )
 
 func main() {
-	svc, svcIAM := config.AWSConfig()
-	client, err := config.ConfigOpenShift()
+	sessAWS := config.AWSConfigSess()
+	oc, err := config.OpenShiftConfig()
 	if err != nil {
 		log.Fatalf("Failed to get client, %v", err)
 	}
-	infra := ec2_instances.GetInfrastrcture(client)
-	vpcID, err := ec2_instances.GetVPCByInfrastructure(svc, infra)
-	if err != nil {
-		log.Fatalf("We failed to find our vpc, %v", err)
-	}
-	ec2_instances.CreateEC2WinC(svc, svcIAM, vpcID, infra.Status.InfrastructureName, "", "", "")
+	ec2_instances.CreateEC2WinC(sessAWS, oc, "", "", "")
 }

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
 	client "github.com/openshift/client-go/config/clientset/versioned"
 	"k8s.io/client-go/tools/clientcmd"
 	_ "k8s.io/client-go/tools/clientcmd"
@@ -22,7 +23,7 @@ func contains(slice *[]interface{}, item *interface{}) bool {
 	}
 	return false
 }
-func AWSConfig() *ec2.EC2 {
+func AWSConfig() (*ec2.EC2, *iam.IAM) {
 	// Grab settings from flag values
 	// TODO: Default values may contain redhat information (consider removing default values before public facing)
 	credPath := flag.String("awsconfig", os.Getenv("HOME")+"/.aws/credentials", "Get absolute path of aws credentials")
@@ -34,7 +35,8 @@ func AWSConfig() *ec2.EC2 {
 		Region:      aws.String(*region),
 	}))
 	svc := ec2.New(sess, aws.NewConfig())
-	return svc
+	svcIam:=iam.New(sess, aws.NewConfig())
+	return svc, svcIam
 }
 
 // get aws instance id

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -12,6 +12,8 @@ import (
 	"os"
 )
 
+// AWSConfigSess uses AWS credentials to create a session for interacting with AWS EC2
+// returns an AWS session
 func AWSConfigSess(credPath, credAccount, region *string) *session.Session {
 	// Grab settings from flag values
 	// TODO: Default values gear towards RedHat Boston Office (consider removing default values before public facing)
@@ -25,6 +27,7 @@ func AWSConfigSess(credPath, credAccount, region *string) *session.Session {
 	return sess
 }
 
+// OpenShiftConfig uses kubeconfig to create a client for existing openshift cluster
 // Return openshift Client
 func OpenShiftConfig(kubeConfigPath *string) (*client.Clientset, error) {
 	log.Println("kubeconfig source: ", *kubeConfigPath)

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -6,8 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/iam"
 	client "github.com/openshift/client-go/config/clientset/versioned"
 	"k8s.io/client-go/tools/clientcmd"
 	_ "k8s.io/client-go/tools/clientcmd"
@@ -15,15 +13,7 @@ import (
 	"os"
 )
 
-func contains(slice *[]interface{}, item *interface{}) bool {
-	for i := range *slice {
-		if (*slice)[i] == *item {
-			return true
-		}
-	}
-	return false
-}
-func AWSConfig() (*ec2.EC2, *iam.IAM) {
+func AWSConfigSess() *session.Session {
 	// Grab settings from flag values
 	// TODO: Default values may contain redhat information (consider removing default values before public facing)
 	credPath := flag.String("awsconfig", os.Getenv("HOME")+"/.aws/credentials", "Get absolute path of aws credentials")
@@ -34,16 +24,14 @@ func AWSConfig() (*ec2.EC2, *iam.IAM) {
 		Credentials: credentials.NewSharedCredentials(*credPath, *credAccount),
 		Region:      aws.String(*region),
 	}))
-	svc := ec2.New(sess, aws.NewConfig())
-	svcIam:=iam.New(sess, aws.NewConfig())
-	return svc, svcIam
+	return sess
 }
 
 // get aws instance id
 
 // TODO: consult https://github.com/openshift/cluster-kube-scheduler-operator/blob/master/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go#L49 using informer
 // Return openshift Client
-func ConfigOpenShift() (*client.Clientset, error) {
+func OpenShiftConfig() (*client.Clientset, error) {
 	kubeConfig := flag.String("kubeconfig", os.Getenv("HOME")+"/.kube/kubeconfig", "absolute path to the kubeconfig file")
 	flag.Parse()
 	log.Println("kubeconfig source: ", *kubeConfig)

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -7,9 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	v1 "github.com/openshift/api/config/v1"
 	client "github.com/openshift/client-go/config/clientset/versioned"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	_ "k8s.io/client-go/tools/clientcmd"
 	"log"
@@ -39,33 +37,7 @@ func AWSConfig() *ec2.EC2 {
 	return svc
 }
 
-func GetVPCByInfrastructure(svc *ec2.EC2, infra v1.Infrastructure) (string, error) {
-	res, err := svc.DescribeVpcs(&ec2.DescribeVpcsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("tag:Name"),
-				Values: aws.StringSlice([]string{infra.Status.InfrastructureName + "-vpc"}), //TODO: use this kubernetes.io/cluster/{infraName}: owned
-			},
-			{
-				Name:   aws.String("state"),
-				Values: aws.StringSlice([]string{"available"}),
-			},
-		},
-	})
-	if err != nil {
-		log.Panicf("Unable to describe VPCs, %v", err)
-	}
-	if len(res.Vpcs) == 0 {
-		log.Panicf("No VPCs found.")
-		return "", err
-	} else if len(res.Vpcs) > 1 {
-		log.Panicf("More than one VPCs are found, we returned the first one")
-	}
-	return *res.Vpcs[0].VpcId, err
-}
-
 // get aws instance id
-
 
 // TODO: consult https://github.com/openshift/cluster-kube-scheduler-operator/blob/master/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go#L49 using informer
 // Return openshift Client
@@ -81,32 +53,5 @@ func ConfigOpenShift() (*client.Clientset, error) {
 	if err != nil {
 		log.Fatalf("Error conveting rest client into OpenShift versioned client, %v", err)
 	}
-	thing,_:=ocClient.ConfigV1().Images().List(metav1.ListOptions{})
-	println(thing)
 	return ocClient, nil
 }
-
-func GetInfrastrcture(c *client.Clientset) v1.Infrastructure {
-
-	infra, err := c.ConfigV1().Infrastructures().List(metav1.ListOptions{})
-	if err != nil || infra == nil || len(infra.Items) != 1 {
-		log.Fatalf("Error getting infrastructure, %v", err)
-	}
-	return infra.Items[0]
-}
-
-//func ConfigOpenShift() (client.Client, error) {
-//	c := config.GetConfigOrDie()
-//	return client.New(c, client.Options{})
-//}
-//
-//// get infraID
-//func GetInfrastrctureName(c client.Client) (string, error) {
-//	infra := &configv1.Infrastructure{}
-//	err := c.Get(context.Background(), types.NamespacedName{Name: "cluster"}, infra)
-//	if err !=nil{
-//		print(err.Error())
-//	}
-//	return infra.Status.InfrastructureName, nil
-//	//return utils.LoadInfrastructureName(c, logrus.New())
-//}

--- a/pkg/ec2_instances/ec2_instance.go
+++ b/pkg/ec2_instances/ec2_instance.go
@@ -2,57 +2,34 @@ package ec2_instances
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	v1 "github.com/openshift/api/config/v1"
+	client "github.com/openshift/client-go/config/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
+	"strings"
+
 	"net/http"
 )
 
-func CreateEC2WinC(svc *ec2.EC2, vpcID, imageId, instanceType, keyName string) {
+func CreateEC2WinC(svc *ec2.EC2, vpcID, infraID, imageId, instanceType, keyName string) {
 
 	if imageId == "" {
-		imageId = "ami-04ca2d0801450d495" // windows server 2019
+		imageId = "ami-0943eb2c39917fc11" // Default using Aravindh's firewall disabled image (Does not always have firewall disabled) AWS windows server 2019 is ami-04ca2d0801450d495
 	}
 	if instanceType == "" {
-		instanceType = "m4.large" 
+		instanceType = "m4.large"
 	}
 	if keyName == "" {
 		keyName = "libra" // use libra.pem
 	}
-	// create a subnet based on vpcID
-	var subnetID string
-	subnet, err := svc.CreateSubnet(&ec2.CreateSubnetInput{
-		CidrBlock: aws.String("10.0.0.0/16"),
-		VpcId:     aws.String(vpcID),
-	})
-	if err != nil {
-		//log.Fatalf("Failed to create subnet based on given VpcID: %v, %v", vpcID, err)
-		subnets, err := svc.DescribeSubnets(&ec2.DescribeSubnetsInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: aws.StringSlice([]string{vpcID}),
-				},
-				{
-					Name:   aws.String("tag-key"),
-					Values: aws.StringSlice([]string{"kubernetes.io/role/internal-elb"}), // indication of private net
-				},
-				//{
-				//	Name:   aws.String("cidr-block"),
-				//	Values: aws.StringSlice([]string{"10.0.0.0/16"}),
-				//},
-			},
-		})
-		if err != nil {
-			log.Fatalf("Failed to create or search subnet based on given VpcID: %v, %v", vpcID, err)
-		}
-		//TODO: exclude private subnets
-		subnetID = *subnets.Subnets[0].SubnetId
-	} else {
-		subnetID = *subnet.Subnet.SubnetId
-	}
+	workerSG := getClusterSGID(svc, infraID, "worker")
+
+	subnetID, err := getPubSubnetOrCreate(svc, vpcID, infraID)
 	sg, err := svc.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
-		GroupName:   aws.String("bsong-winc-node"),
+		GroupName:   aws.String(infraID + "winc-sg"),
 		Description: aws.String("security group for rdp and all traffic"),
 		VpcId:       aws.String(vpcID),
 	})
@@ -67,7 +44,8 @@ func CreateEC2WinC(svc *ec2.EC2, vpcID, imageId, instanceType, keyName string) {
 		SubnetId:         aws.String(subnetID),
 		MinCount:         aws.Int64(1),
 		MaxCount:         aws.Int64(1),
-		SecurityGroupIds: []*string{aws.String(*sg.GroupId)},
+		iam
+		SecurityGroupIds: []*string{aws.String(*sg.GroupId), aws.String(workerSG)},
 	})
 	if err != nil {
 		log.Fatalf("Could not create instance: %v", err)
@@ -78,11 +56,12 @@ func CreateEC2WinC(svc *ec2.EC2, vpcID, imageId, instanceType, keyName string) {
 	_, err = svc.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
 		GroupId: aws.String(*sg.GroupId),
 		IpPermissions: []*ec2.IpPermission{
-			//(&ec2.IpPermission{}).
-			//	SetIpProtocol("-1").
-			//	SetIpRanges([]*ec2.IpRange{
-			//		{CidrIp: aws.String("0.0.0.0/16")},
-			//	}),
+			(&ec2.IpPermission{}).
+				SetIpProtocol("-1").
+				SetIpRanges([]*ec2.IpRange{
+					(&ec2.IpRange{}).
+						SetCidrIp("10.0.0.0/16"),
+				}),
 			(&ec2.IpPermission{}).
 				SetIpProtocol("tcp").
 				SetFromPort(3389).
@@ -125,4 +104,114 @@ func getMyIp() string {
 		log.Panic("Failed to read external IP Addr")
 	}
 	return buf.String()
+}
+
+func GetInfrastrcture(c *client.Clientset) v1.Infrastructure {
+	infra, err := c.ConfigV1().Infrastructures().List(metav1.ListOptions{})
+	if err != nil || infra == nil || len(infra.Items) != 1 { // we should only have 1 infrastructure
+		log.Fatalf("Error getting infrastructure, %v", err)
+	}
+	return infra.Items[0]
+}
+
+func GetVPCByInfrastructure(svc *ec2.EC2, infra v1.Infrastructure) (string, error) {
+	res, err := svc.DescribeVpcs(&ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: aws.StringSlice([]string{infra.Status.InfrastructureName + "-vpc"}), //TODO: use this kubernetes.io/cluster/{infraName}: owned
+			},
+			{
+				Name:   aws.String("state"),
+				Values: aws.StringSlice([]string{"available"}),
+			},
+		},
+	})
+	if err != nil {
+		log.Panicf("Unable to describe VPCs, %v", err)
+	}
+	if len(res.Vpcs) == 0 {
+		log.Panicf("No VPCs found.")
+		return "", err
+	} else if len(res.Vpcs) > 1 {
+		log.Panicf("More than one VPCs are found, we returned the first one")
+	}
+	return *res.Vpcs[0].VpcId, err
+}
+
+func getPubSubnetOrCreate(svc *ec2.EC2, vpcID, infraID string) (string, error) {
+	// search subnet by the vpcid
+	subnets, err := svc.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: aws.StringSlice([]string{vpcID}), // grab subnet owned by the vpcID
+			},
+			//{
+			//	Name:   aws.String("cidr-block"),
+			//	Values: aws.StringSlice([]string{"10.0.0.0/16"}),
+			//},
+		},
+	})
+	if err != nil {
+		log.Println("failed to search subnet based on given VpcID: %v, %v, will create one instead", vpcID, err)
+		// create a subnet based on vpcID
+		subnet, err := svc.CreateSubnet(&ec2.CreateSubnetInput{ // create subnet under the vpc (most likely not used since openshift-installer creates 6+ of them)
+			CidrBlock: aws.String("10.0.0.0/16"),
+			VpcId:     aws.String(vpcID),
+		})
+		if err != nil {
+			log.Fatalf("Failed to search or create public subnet based on given VpcID: %v, %v", vpcID, err)
+		}
+		return *subnet.Subnet.SubnetId, err
+	}
+	for _, subnet := range subnets.Subnets { // find public subnet within the vpc
+		for _, tag := range subnet.Tags {
+			if *tag.Key == "Name" && strings.Contains(*tag.Value, infraID+"-public-") {
+				return *subnet.SubnetId, err
+			}
+		}
+	}
+	return "", fmt.Errorf("failed to find public subnet in vpc: %v", vpcID)
+}
+
+func getClusterSGID(svc *ec2.EC2, infraID, clusterFunction string) string {
+	sg, err := svc.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: aws.StringSlice([]string{infraID + "-" + clusterFunction + "-sg"}),
+			},
+			{
+				Name:   aws.String("tag:kubernetes.io/cluster/" + infraID),
+				Values: aws.StringSlice([]string{"owned"}),
+			},
+		},
+	})
+	if err != nil {
+		log.Panicf("Failed to attach security group of openshift cluster worker, please manually add it, %v", err)
+	}
+	if sg == nil || len(sg.SecurityGroups) > 1 {
+		log.Panicf("nil or more than one security groups are found for the openshift cluster %v nodes, this should not happen, we attached the first one.", clusterFunction)
+	}
+	return *sg.SecurityGroups[0].GroupId
+}
+
+func getIAMrole(svc *ec2.EC2, infraID, clusterFunction string) ec2.IamInstanceProfile {
+	iams, err:=svc.DescribeIamInstanceProfileAssociations(&ec2.DescribeIamInstanceProfileAssociationsInput{
+		Filters:[]*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: aws.StringSlice([]string{infraID + "-" + clusterFunction + "-role"}),
+			},
+			{
+				Name:   aws.String("tag:kubernetes.io/cluster/" + infraID),
+				Values: aws.StringSlice([]string{"owned"}),
+			},
+		},
+	})
+	if err!=nil{
+		log.Panicf("failed to find iam role, please attache manually")
+	}
+	return *iams.IamInstanceProfileAssociations[0].IamInstanceProfile
 }


### PR DESCRIPTION
The current status is able to create and destroy windows node and security group for RDP.
All requirements are met and code is locally tested
This project uses go.mod
simple command including 
```bash 
./winc_node_setup create -awscred=/abs/path/to/your/aws/credentials -kubeconfig=/abs/path/to/your/kubeconfig

./winc_node_setup destroy -awscred=/abs/path/to/your/aws/credentials
```
/cc @gmarkley-VI
/cc @ravisantoshgudimetla
/cc @aravindhp